### PR TITLE
feat: convert glsl shaders to sksl for react native

### DIFF
--- a/packages/shaders-react-native/src/glsl-to-sksl.ts
+++ b/packages/shaders-react-native/src/glsl-to-sksl.ts
@@ -1,0 +1,20 @@
+export function glslToSkSL(source: string): string {
+  let result = source;
+  // Remove WebGL directives not supported by SkSL
+  result = result.replace(/^#version\s+\d+\s+es\n/, '');
+  result = result.replace(/^precision\s+mediump\s+float;\n/, '');
+  // Remove explicit out variable declarations
+  result = result.replace(/^\s*out\s+vec4\s+\w+;\n/m, '');
+  // Convert main entry point
+  result = result.replace(/void\s+main\s*\(\s*\)\s*{\n/, 'vec4 main(vec2 fragCoord) {\n');
+  // Replace fragColor assignments with return statements
+  result = result.replace(/fragColor\s*=\s*/g, 'return ');
+  // Map GLSL types to SkSL types
+  result = result.replace(/\bvec2\b/g, 'float2');
+  result = result.replace(/\bvec3\b/g, 'float3');
+  result = result.replace(/\bvec4\b/g, 'float4');
+  result = result.replace(/\bmat2\b/g, 'float2x2');
+  result = result.replace(/\bmat3\b/g, 'float3x3');
+  result = result.replace(/\bmat4\b/g, 'float4x4');
+  return result;
+}

--- a/packages/shaders-react-native/src/shader-mount.tsx
+++ b/packages/shaders-react-native/src/shader-mount.tsx
@@ -12,6 +12,7 @@ import {
 import { PixelRatio, type LayoutChangeEvent, type ViewProps } from 'react-native';
 import { useMergeRefs } from './use-merge-refs.js';
 import type { ShaderMotionParams } from '@paper-design/shaders';
+import { glslToSkSL } from './glsl-to-sksl.js';
 
 interface ShaderMountUniformsReactNative {
   [key: string]:
@@ -86,9 +87,9 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<CanvasRef, Sha
   const canvasRef = useRef<CanvasRef>(null);
   const mergedRef = useMergeRefs([canvasRef, forwardedRef]) as React.Ref<CanvasRef>;
 
-  const effectRef = useRef(Skia.RuntimeEffect.Make(fragmentShader));
+  const effectRef = useRef(Skia.RuntimeEffect.Make(glslToSkSL(fragmentShader)));
   useEffect(() => {
-    effectRef.current = Skia.RuntimeEffect.Make(fragmentShader);
+    effectRef.current = Skia.RuntimeEffect.Make(glslToSkSL(fragmentShader));
   }, [fragmentShader]);
 
   const [uniforms, setUniforms] = React.useState<Record<string, unknown>>({ u_time: frame });

--- a/packages/shaders-react-native/src/shader-mount.tsx
+++ b/packages/shaders-react-native/src/shader-mount.tsx
@@ -1,29 +1,14 @@
 'use client';
 
 import React, { useEffect, useRef, forwardRef } from 'react';
-import {
-  Canvas,
-  Fill,
-  Shader as SkiaShader,
-  Skia,
-  type CanvasRef,
-  type SkImage,
-} from '@shopify/react-native-skia';
+import { Canvas, Fill, Shader as SkiaShader, Skia, type CanvasRef, type SkImage } from '@shopify/react-native-skia';
 import { PixelRatio, type LayoutChangeEvent, type ViewProps } from 'react-native';
 import { useMergeRefs } from './use-merge-refs.js';
 import type { ShaderMotionParams } from '@paper-design/shaders';
 import { glslToSkSL } from './glsl-to-sksl.js';
 
 interface ShaderMountUniformsReactNative {
-  [key: string]:
-    | string
-    | boolean
-    | number
-    | number[]
-    | number[][]
-    | SkImage
-    | HTMLImageElement
-    | undefined;
+  [key: string]: string | boolean | number | number[] | number[][] | SkImage | HTMLImageElement | undefined;
 }
 
 export interface ShaderMountProps extends Omit<ViewProps, 'ref'>, ShaderMotionParams {
@@ -160,12 +145,7 @@ export const ShaderMount: React.FC<ShaderMountProps> = forwardRef<CanvasRef, Sha
   if (!effectRef.current) return null;
 
   return (
-    <Canvas
-      ref={mergedRef as unknown as React.Ref<unknown>}
-      style={style}
-      onLayout={handleLayout}
-      {...viewProps}
-    >
+    <Canvas ref={mergedRef} style={style} onLayout={handleLayout} {...viewProps}>
       <Fill>
         <SkiaShader source={effectRef.current} uniforms={uniforms as any} />
       </Fill>


### PR DESCRIPTION
## Summary
- convert GLSL shaders to SkSL for React Native runtime
- preprocess fragment shaders before creating Skia RuntimeEffect

## Testing
- `bun run build` *(fails: Could not build type declaration files)*

------
https://chatgpt.com/codex/tasks/task_e_68acf350ad6c832a8e8d3daed65d65c2